### PR TITLE
Adds GH workflow to build, sign and release py packages.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,10 @@ jobs:
         name: python-package-distributions
         path: dist/
 
+    - name: clean up pgk dists
+      run: |
+        rm dist/CHANGELOG.md
+    
     - name: Publish distribution to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - wf/*
+
+jobs:
+  build:
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Requests AWS credentials using OIDC to assume the specified role
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: 'v3.0.5'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install twine setuptools wheel build
+
+      - name: Build package
+        run: |
+          python -m build
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum *.tar.gz *.whl > checksums.txt
+
+      - name: sign checksums
+        run: |
+          cd dist
+          cosign sign-blob \
+            --key "awskms:///${{ secrets.AWS_KMS_KEY_ID }}" \
+            --bundle checksums.txt.sig \
+            checksums.txt \
+            --yes
+
+      - name: Create change log
+        run: |
+          echo "Release ${{ github.ref_name }}" > dist/CHANGELOG.md
+          echo "" >> dist/CHANGELOG.md
+          echo "Changes:" >> dist/CHANGELOG.md
+          git log --pretty=format:"- %s" $(git describe --tags --abbrev=0)..HEAD >> dist/CHANGELOG.md
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi-gh-release:
+    name: >-
+      Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: dist/*
+        body_path: dist/CHANGELOG.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Remove checksums and signatures from the distribution directory
+      run: |
+        rm dist/checksums.txt dist/checksums.txt.sig dist/CHANGELOG.md
+
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-to-testpypi:
+    name: Publish Python distribution to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Remove checksums and signatures from the distribution directory
+      run: |
+        rm dist/checksums.txt dist/checksums.txt.sig dist/CHANGELOG.md
+
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
     branches:
       - main
-  workflow_dispatch:
+      - wf/ghactions
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,11 @@ jobs:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        files: dist/*
+        files: |
+          dist/*.tar.gz
+          dist/*.whl
+          dist/checksums.txt
+          dist/checksums.txt.sig
         body_path: dist/CHANGELOG.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - wf/*
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,9 +122,11 @@ jobs:
     needs:
     - build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
-    - name: Download all the dists
+    - name: Download pkg dists
       uses: actions/download-artifact@v4
       with:
         name: python-package-distributions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,26 +10,12 @@ on:
 
 jobs:
   build:
-    permissions:
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      # Requests AWS credentials using OIDC to assume the specified role
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v4.0.0
-        with:
-          cosign-release: 'v3.0.5'
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -45,20 +31,6 @@ jobs:
       - name: Build package
         run: |
           python -m build
-
-      - name: Generate checksums
-        run: |
-          cd dist
-          sha256sum *.tar.gz *.whl > checksums.txt
-
-      - name: sign checksums
-        run: |
-          cd dist
-          cosign sign-blob \
-            --key "awskms:///${{ secrets.AWS_KMS_KEY_ID }}" \
-            --bundle checksums.txt.sig \
-            checksums.txt \
-            --yes
 
       - name: Create change log
         run: |
@@ -80,7 +52,9 @@ jobs:
     needs:
     - build
     runs-on: ubuntu-latest
+
     permissions:
+      id-token: write
       contents: write
 
     steps:
@@ -90,6 +64,39 @@ jobs:
         name: python-package-distributions
         path: dist/
 
+    # Requests AWS credentials using OIDC to assume the specified role
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@v4.0.0
+      with:
+        cosign-release: 'v3.0.5'
+
+    - name: Generate checksums
+      run: |
+        cd dist
+        sha256sum *.tar.gz *.whl > checksums.txt
+
+    - name: sign checksums
+      run: |
+        cd dist
+        cosign sign-blob \
+          --key "awskms:///${{ secrets.AWS_KMS_KEY_ID }}" \
+          --bundle checksums.txt.sig \
+          checksums.txt \
+          --yes
+
+    - name: Store public key for signature verification
+      run: |
+        cd dist
+        cosign public-key \
+          --key "awskms:///${{ secrets.AWS_KMS_KEY_ID }}" \
+          > public_key.pem
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
@@ -98,13 +105,14 @@ jobs:
           dist/*.whl
           dist/checksums.txt
           dist/checksums.txt.sig
+          dist/public_key.pem
         body_path: dist/CHANGELOG.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Remove checksums and signatures from the distribution directory
       run: |
-        rm dist/checksums.txt dist/checksums.txt.sig dist/CHANGELOG.md
+        rm dist/checksums.txt dist/checksums.txt.sig dist/CHANGELOG.md 
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
@@ -121,10 +129,6 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-
-    - name: Remove checksums and signatures from the distribution directory
-      run: |
-        rm dist/checksums.txt dist/checksums.txt.sig dist/CHANGELOG.md
 
     - name: Publish distribution to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:
@@ -105,8 +108,6 @@ jobs:
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
 
   publish-to-testpypi:
     name: Publish Python distribution to TestPyPI
@@ -129,4 +130,3 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
- Build job sets up the environment with python and cosign and builds the packages
- cheksums.txt is generated and then signed using cosign
- CHANGELOG.md is generated to be used for github release
- A release is made to pypi and gh if the event trigger is a tag
- A release is made to test pypi
---
Publishing to pypi can be done using a trusted publisher (see: https://github.com/suprsend/suprsend-py-sdk/actions/runs/22797310984/attempts/1#summary-66133832378). This will require configs on the existing pypi account used to publish this